### PR TITLE
Fixed the 30s blank during boot with minigbm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 
 include common.mk
 
+PKG_CONFIG := pkg-config
+
 PC_DEPS = libdrm
 PC_CFLAGS := $(shell $(PKG_CONFIG) --cflags $(PC_DEPS))
 PC_LIBS := $(shell $(PKG_CONFIG) --libs $(PC_DEPS))

--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,21 @@ CFLAGS += -std=c99 -Wall -Wsign-compare -Wpointer-arith -Wcast-qual \
 
 ifdef DRV_AMDGPU
 	CFLAGS += $(shell $(PKG_CONFIG) --cflags libdrm_amdgpu)
+	CFLAGS += -DDRV_AMDGPU
 	LDLIBS += -lamdgpuaddr
 endif
 ifdef DRV_EXYNOS
 	CFLAGS += $(shell $(PKG_CONFIG) --cflags libdrm_exynos)
+	CFLAGS += -DDRV_EXYNOS
 endif
 ifdef DRV_I915
 	CFLAGS += $(shell $(PKG_CONFIG) --cflags libdrm_intel)
+	CFLAGS += -DDRV_I915
 	LDLIBS += $(shell $(PKG_CONFIG) --libs libdrm_intel)
 endif
 ifdef DRV_ROCKCHIP
 	CFLAGS += $(shell $(PKG_CONFIG) --cflags libdrm_rockchip)
+	CFLAGS += -DDRV_ROCKCHIP
 endif
 
 CPPFLAGS += $(PC_CFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,5 @@ install: all
 	install -D -m 755 $(OUT)/$(MINIGBM_FILENAME) $(DESTDIR)/$(LIBDIR)
 	ln -sf $(MINIGBM_FILENAME) $(DESTDIR)/$(LIBDIR)/libgbm.so
 	ln -sf $(MINIGBM_FILENAME) $(DESTDIR)/$(LIBDIR)/libgbm.so.$(GBM_VERSION_MAJOR)
-	install -D -m 0644 $(SRC)/gbm.pc $(DESTDIR)$(LIBDIR)/pkgconfig/gbm.pc
-	install -D -m 0644 $(SRC)/gbm.h $(DESTDIR)/usr/include/gbm.h
+	install -D -m 0644 $(SRC)/gbm.pc $(DESTDIR)/$(LIBDIR)/pkgconfig/gbm.pc
+	install -D -m 0644 $(SRC)/gbm.h $(DESTDIR)/include/gbm.h

--- a/cros_gralloc/cros_alloc_device.cc
+++ b/cros_gralloc/cros_alloc_device.cc
@@ -104,7 +104,7 @@ static int cros_gralloc_alloc(alloc_device_t *dev, int w, int h, int format,
 			      int usage, buffer_handle_t *handle, int *stride)
 {
 	auto mod = (struct cros_gralloc_module *) dev->common.module;
-	std::lock_guard<std::mutex> lock(mod->mutex);
+	ScopedSpinLock lock(mod->lock);
 
 	auto bo = cros_gralloc_bo_create(mod->drv, w, h, format, usage);
 	if (!bo)
@@ -131,7 +131,7 @@ static int cros_gralloc_free(alloc_device_t *dev, buffer_handle_t handle)
 	struct cros_gralloc_bo *bo;
 	auto hnd = (struct cros_gralloc_handle *) handle;
 	auto mod = (struct cros_gralloc_module *) dev->common.module;
-	std::lock_guard<std::mutex> lock(mod->mutex);
+	ScopedSpinLock lock(mod->lock);
 
 	if (cros_gralloc_validate_handle(hnd)) {
 		cros_gralloc_error("Invalid handle.");
@@ -155,7 +155,7 @@ static int cros_gralloc_close(struct hw_device_t *dev)
 {
 	auto mod = (struct cros_gralloc_module *) dev->module;
 	auto alloc = (struct alloc_device_t *) dev;
-	std::lock_guard<std::mutex> lock(mod->mutex);
+	ScopedSpinLock lock(mod->lock);
 
 	if (mod->drv) {
 		drv_destroy(mod->drv);
@@ -174,7 +174,7 @@ int cros_gralloc_open(const struct hw_module_t *mod, const char *name,
 		      struct hw_device_t **dev)
 {
 	auto module = (struct cros_gralloc_module *) mod;
-	std::lock_guard<std::mutex> lock(module->mutex);
+	ScopedSpinLock lock(module->lock);
 
 	if (module->drv)
 		return CROS_GRALLOC_ERROR_NONE;

--- a/cros_gralloc/cros_gralloc.h
+++ b/cros_gralloc/cros_gralloc.h
@@ -9,7 +9,7 @@
 
 #include "cros_gralloc_helpers.h"
 
-#include <mutex>
+#include <atomic>
 #include <unordered_set>
 #include <unordered_map>
 
@@ -26,10 +26,44 @@ struct handle_info {
 	int32_t registrations;
 };
 
+class SpinLock {
+    public:
+        void lock() {
+          while (atomic_lock_.test_and_set(std::memory_order_acquire)) {
+          }
+        }
+
+        void unlock() {
+          atomic_lock_.clear(std::memory_order_release);
+        }
+
+    private:
+        std::atomic_flag atomic_lock_ = ATOMIC_FLAG_INIT;
+};
+
+class ScopedSpinLock {
+    public:
+        explicit ScopedSpinLock(SpinLock& lock) : lock_(lock) {
+        lock_.lock();
+        locked_ = true;
+        }
+
+        ~ScopedSpinLock() {
+          if (locked_) {
+            lock_.unlock();
+            locked_ = false;
+          }
+        }
+
+    private:
+        SpinLock& lock_;
+        bool locked_;
+};
+
 struct cros_gralloc_module {
 	gralloc_module_t base;
 	struct driver *drv;
-	std::mutex mutex;
+	SpinLock lock;
 	std::unordered_map<cros_gralloc_handle*, handle_info> handles;
 	std::unordered_map<uint32_t, cros_gralloc_bo*> buffers;
 };

--- a/cros_gralloc/cros_gralloc_module.cc
+++ b/cros_gralloc/cros_gralloc_module.cc
@@ -51,7 +51,7 @@ static int cros_gralloc_register_buffer(struct gralloc_module_t const* module,
 	struct cros_gralloc_bo *bo;
 	auto hnd = (struct cros_gralloc_handle *) handle;
 	auto mod = (struct cros_gralloc_module *) module;
-	std::lock_guard<std::mutex> lock(mod->mutex);
+	ScopedSpinLock lock(mod->lock);
 
 	if (cros_gralloc_validate_handle(hnd)) {
 		cros_gralloc_error("Invalid handle.");
@@ -122,7 +122,7 @@ static int cros_gralloc_unregister_buffer(struct gralloc_module_t const* module,
 	struct cros_gralloc_bo *bo;
 	auto hnd = (struct cros_gralloc_handle *) handle;
 	auto mod = (struct cros_gralloc_module *) module;
-	std::lock_guard<std::mutex> lock(mod->mutex);
+	ScopedSpinLock lock(mod->lock);
 
 	if (cros_gralloc_validate_handle(hnd)) {
 		cros_gralloc_error("Invalid handle.");
@@ -154,7 +154,7 @@ static int cros_gralloc_lock(struct gralloc_module_t const* module,
 	struct cros_gralloc_bo *bo;
 	auto mod = (struct cros_gralloc_module *) module;
 	auto hnd = (struct cros_gralloc_handle *) handle;
-	std::lock_guard<std::mutex> lock(mod->mutex);
+	ScopedSpinLock lock(mod->lock);
 
 	if (cros_gralloc_validate_handle(hnd)) {
 		cros_gralloc_error("Invalid handle.");
@@ -198,7 +198,7 @@ static int cros_gralloc_unlock(struct gralloc_module_t const* module,
 	struct cros_gralloc_bo *bo;
 	auto hnd = (struct cros_gralloc_handle *) handle;
 	auto mod = (struct cros_gralloc_module *) module;
-	std::lock_guard<std::mutex> lock(mod->mutex);
+	ScopedSpinLock lock(mod->lock);
 
 	if (cros_gralloc_validate_handle(hnd)) {
 		cros_gralloc_error("Invalid handle.");
@@ -228,7 +228,7 @@ static int cros_gralloc_perform(struct gralloc_module_t const* module,
 	buffer_handle_t handle;
 	uint32_t *out_width, *out_height, *out_stride;
 	auto mod = (struct cros_gralloc_module *) module;
-	std::lock_guard<std::mutex> lock(mod->mutex);
+	ScopedSpinLock lock(mod->lock);
 
 	switch (op) {
 	case GRALLOC_DRM_GET_STRIDE:
@@ -292,7 +292,7 @@ static int cros_gralloc_lock_ycbcr(struct gralloc_module_t const* module,
 	struct cros_gralloc_bo *bo;
 	auto hnd = (struct cros_gralloc_handle *) handle;
 	auto mod = (struct cros_gralloc_module *) module;
-	std::lock_guard<std::mutex> lock(mod->mutex);
+	ScopedSpinLock lock(mod->lock);
 
 	if (cros_gralloc_validate_handle(hnd)) {
 		cros_gralloc_error("Invalid handle.");

--- a/helpers.c
+++ b/helpers.c
@@ -375,7 +375,8 @@ void drv_modify_combination(struct driver *drv, uint32_t format,
 
 struct kms_item *drv_query_kms(struct driver *drv, uint32_t *num_items)
 {
-	uint64_t flag, usage;
+	uint64_t usage;
+	uint64_t flag = -1;
 	struct kms_item *items;
 	uint32_t i, j, k, allocations, item_size;
 


### PR DESCRIPTION
The gralloc Apis are accessed by mutiple threads and in
the end of the bootanimation the main thread is blocked in
the mutex and not unblocked.So replaced the mutex by spinlock
in the gralloc Apis.

This solved the 30s delay between bootanimation and homescreen
during first boot

Jira: 169
Test: No long delay between bootanimation and homescreen

Signed-off-by: Pallavi G <pallavi.g@intel.com>
Signed-off-by: Bhardwaj Munishx <munishx.bhardwaj@intel.com>