### PR TITLE
Delete Gralloc when device is closed.

### DIFF
--- a/cros_gralloc/gralloc1/cros_gralloc1_module.cc
+++ b/cros_gralloc/gralloc1/cros_gralloc1_module.cc
@@ -586,6 +586,11 @@ int CrosGralloc1::HookDevOpen(const struct hw_module_t *mod,
 
 // static
 int CrosGralloc1::HookDevClose(hw_device_t * /*dev*/) {
+    if (pCrosGralloc1) {
+      delete pCrosGralloc1;
+      pCrosGralloc1 = NULL;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
Jira: None
Test: Gralloc pointer is deleted when the close is called.

Signed-off-by: Kalyan Kondapally <kalyan.kondapally@intel.com>
Signed-off-by: Harish Krupo <harish.krupo.kps@intel.com>